### PR TITLE
feat: Product 생성할때 Option 동시 추가할 수 있도록 변경

### DIFF
--- a/src/product/dto/add-option-cascade.input.ts
+++ b/src/product/dto/add-option-cascade.input.ts
@@ -1,0 +1,9 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { IsString } from 'class-validator';
+
+@InputType()
+export class AddOptionCascade {
+  @IsString()
+  @Field()
+  name: string;
+}

--- a/src/product/dto/add-product.input.ts
+++ b/src/product/dto/add-product.input.ts
@@ -1,5 +1,8 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
-import { IsString, IsInt, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsString, IsInt, IsOptional, IsArray, ArrayNotEmpty, ArrayUnique, ValidateNested } from 'class-validator';
+
+import { AddOptionCascade } from './add-option-cascade.input';
 
 @InputType()
 export class AddProductInput {
@@ -24,4 +27,13 @@ export class AddProductInput {
   @IsString()
   @Field({ nullable: true })
   description?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Type(() => AddOptionCascade)
+  @ArrayUnique()
+  @Field(() => [AddOptionCascade], { nullable: true })
+  options?: AddOptionCascade[];
 }

--- a/src/product/entity/product.entity.ts
+++ b/src/product/entity/product.entity.ts
@@ -40,7 +40,7 @@ export class Product {
   store: Store;
 
   @Field(() => [Option])
-  @OneToMany(() => Option, (item) => item.product)
+  @OneToMany(() => Option, (item) => item.product, { cascade: ['insert', 'update'] })
   options: Option[];
 
   @OneToMany(() => OrderProduct, (item) => item.product)

--- a/src/product/interface/add-option-cascade.interface.ts
+++ b/src/product/interface/add-option-cascade.interface.ts
@@ -1,0 +1,4 @@
+export interface IAddOptionCascade {
+  productId?: number;
+  name: string;
+}

--- a/src/product/interface/add-product.interface.ts
+++ b/src/product/interface/add-product.interface.ts
@@ -1,7 +1,10 @@
+import { IAddOptionCascade } from './add-option-cascade.interface';
+
 export interface IAddProduct {
   storeId: number;
   name: string;
   price: number;
   imageUrl?: string;
   description?: string;
+  options?: IAddOptionCascade[];
 }


### PR DESCRIPTION
# 개요
아래 스크린샷과 같이 Mutation을 보내면 Product 추가와 동시에 옵션들이 추가됩니다.

## 작업 내용
- product.entity.ts의 options 필드 옵션에 cascade: ['insert', 'update'] 옵션 추가
- AddProductInput에 options 프로퍼티 및 validation 추가 (add-product.input.ts)
- IAddProduct에 options 프로퍼티 추가 (add-product.interface.ts)
- 동시 추가를 위한 interface 생성 : add-option-cascade.interface.ts
- 동시 추가를 위한 dto 생성 : add-option-cascade.input.ts
## 스크린샷
<img width="637" alt="스크린샷 2022-05-31 오후 2 21 10" src="https://user-images.githubusercontent.com/56436283/171098698-41b9d0ab-938e-4af9-94d5-f4c8379b9e30.png">