### PR TITLE
Option 추가할때 product별로 Option 추가할 수 있도록 Mutation 수정

### DIFF
--- a/src/product/dto/add-product-option.input.ts
+++ b/src/product/dto/add-product-option.input.ts
@@ -1,5 +1,5 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
-import { IsString, IsInt } from 'class-validator';
+import { IsString, IsInt, IsArray, ArrayUnique, ArrayNotEmpty } from 'class-validator';
 
 @InputType()
 export class AddProductOptionInput {
@@ -7,7 +7,10 @@ export class AddProductOptionInput {
   @Field(() => Int)
   productId: number;
 
-  @IsString()
-  @Field()
-  name: string;
+  @IsArray()
+  @ArrayUnique()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  @Field(() => [String])
+  names: string[];
 }

--- a/src/product/interface/add-option.interface.ts
+++ b/src/product/interface/add-option.interface.ts
@@ -1,4 +1,4 @@
 export interface IAddOption {
   productId: number;
-  name: string;
+  names: string[];
 }

--- a/src/product/interface/add-options-frag.interface.ts
+++ b/src/product/interface/add-options-frag.interface.ts
@@ -1,0 +1,4 @@
+export interface IAddOptionFrag {
+  productId: number;
+  name: string;
+}

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { IAddOption } from './interface/add-option.interface';
+import { AddProductOptionInput } from './dto/add-product-option.input';
 import { IAddProduct } from './interface/add-product.interface';
 import { IEditOption } from './interface/edit-option.interface';
 import { IEditProduct } from './interface/edit-product.interface';
@@ -30,8 +30,19 @@ export class ProductService {
     return this.productRepository.updateProduct(productId, product);
   }
 
-  async addOptions(options: IAddOption[]) {
-    const productIds = options.map((v) => v.productId);
+  async addOptions(optionsDto: AddProductOptionInput[]) {
+    let options = [];
+    optionsDto.forEach((option) => {
+      options = options.concat(
+        option.names.map((name) => {
+          return {
+            productId: option.productId,
+            name: name,
+          };
+        }),
+      );
+    });
+    const productIds = optionsDto.map((v) => v.productId);
     const isExistIds = await this.productRepository.existProductByIds(productIds);
     if (!isExistIds) {
       return false;

--- a/src/product/repository/product-option.repository.ts
+++ b/src/product/repository/product-option.repository.ts
@@ -3,14 +3,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
 import { Option } from '../entity/option.entity';
-import { IAddOption } from '../interface/add-option.interface';
+import { IAddOptionFrag } from '../interface/add-options-frag.interface';
 import { IEditOption } from '../interface/edit-option.interface';
 
 @Injectable()
 export class ProductOptionRepository {
   constructor(@InjectRepository(Option) private repository: Repository<Option>) {}
 
-  async addOptions(options: IAddOption[]) {
+  async addOptions(options: IAddOptionFrag[]) {
     await this.repository.save(this.repository.create(options));
     return true;
   }


### PR DESCRIPTION
# 개요
스크린샷과 같이 Option 추가할때 product별로 Option 추가할 수 있도록 Mutation 수정

## 작업 내용
- AddProductOptionInput의 name을 string 배열 names로 수정 및 validation 추가
- IAddOption의 name을 string 배열 names로 수정
- IAddOption의 names를 분할해 {productId, name} 형태를 가지는 IAddOptionFrag 인터페이스 추가
- 위 분할 작업을 하도록 상품 서비스 변경
- 상품 옵션 레포지토리의 인터페이스 수정사항 변경
## 스크린샷
<img width="648" alt="image" src="https://user-images.githubusercontent.com/56436283/172289147-42bce70f-2a7f-444a-a8ed-75ca73cbdc1a.png">
