### PR TITLE
fix: 옵션 추가시 같은 productId가 존재할 때, 추가 되지 않는 문제 해결

### DIFF
--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -34,9 +34,14 @@ export class ProductService {
     return this.productRepository.updateProduct(productId, product);
   }
 
+  async existProductByIds(productIds: number[]) {
+    const uniqueIds = productIds.filter((e, i) => productIds.indexOf(e) === i);
+    return this.productRepository.existProductByUniqueIds(uniqueIds);
+  }
+
   async addOptions(options: IAddOption[]) {
     const productIds = options.map((v) => v.productId);
-    const isExistIds = await this.productRepository.existProductByIds(productIds);
+    const isExistIds = await this.existProductByIds(productIds);
     if (!isExistIds) {
       return false;
     }

--- a/src/product/repository/product.repository.ts
+++ b/src/product/repository/product.repository.ts
@@ -28,10 +28,9 @@ export class ProductRepository {
     return this.repository.findBy({ storeId: In(storeIds) });
   }
 
-  async existProductByIds(ids: number[]) {
+  async existProductByUniqueIds(ids: number[]) {
     const count = await this.repository.count({ where: { id: In(ids) } });
-    const uniqueIds = ids.filter((e, i) => ids.indexOf(e) === i);
-    return count === uniqueIds.length;
+    return count === ids.length;
   }
 
   async addProducts(products: IAddProduct[]) {

--- a/src/product/repository/product.repository.ts
+++ b/src/product/repository/product.repository.ts
@@ -30,7 +30,10 @@ export class ProductRepository {
 
   async existProductByIds(ids: number[]) {
     const count = await this.repository.count({ where: { id: In(ids) } });
-    return count === ids.length;
+    const uniqueIds = ids.filter((e, i) => {
+      return ids.indexOf(e) === i;
+    });
+    return count === uniqueIds.length;
   }
 
   async addProducts(products: IAddProduct[]) {

--- a/src/product/repository/product.repository.ts
+++ b/src/product/repository/product.repository.ts
@@ -30,9 +30,7 @@ export class ProductRepository {
 
   async existProductByIds(ids: number[]) {
     const count = await this.repository.count({ where: { id: In(ids) } });
-    const uniqueIds = ids.filter((e, i) => {
-      return ids.indexOf(e) === i;
-    });
+    const uniqueIds = ids.filter((e, i) => ids.indexOf(e) === i);
     return count === uniqueIds.length;
   }
 


### PR DESCRIPTION
# 개요
옵션 추가시 같은 productId가 존재할 때, 추가 되지 않는 문제 해결

## 작업 내용
- productRepository의 existProductByIds가 중복을 제거한 배열의 길이에 대해서 검사하도록 변경

## 스크린샷
필요하다면 첨부해주세요.
