### PR TITLE
feat: addProducts가 추가된 상품들의 id 배열을 반환하도록 변경

### DIFF
--- a/src/product/product.resolver.ts
+++ b/src/product/product.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Int, Mutation, Parent, ResolveField, Resolver } from '@nestjs/graphql';
 
 import { AddProductOptionInput } from './dto/add-product-option.input';
 import { AddProductInput } from './dto/add-product.input';
@@ -13,7 +13,7 @@ import { ProductService } from './product.service';
 @Resolver(() => Product)
 export class ProductResolver {
   constructor(private readonly productService: ProductService) {}
-  @Mutation(() => Boolean)
+  @Mutation(() => [Int])
   async addProducts(@Args({ name: 'products', type: () => [AddProductInput] }) args: AddProductInput[]) {
     return this.productService.addProducts(args);
   }

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 
 import { IAddOption } from './interface/add-option.interface';
 import { IAddProduct } from './interface/add-product.interface';
@@ -27,7 +27,11 @@ export class ProductService {
   }
 
   async addProducts(products: IAddProduct[]) {
-    return this.productRepository.addProducts(products);
+    const addedProducts = await this.productRepository.addProducts(products);
+    if (addedProducts.length == 0) {
+      throw new BadRequestException('상품 등록 중 오류가 발생했습니다.');
+    }
+    return addedProducts.map((product) => product.id);
   }
 
   async removeProducts(productIds: number[]) {

--- a/src/product/repository/product.repository.ts
+++ b/src/product/repository/product.repository.ts
@@ -35,12 +35,11 @@ export class ProductRepository {
 
   async addProducts(products: IAddProduct[]) {
     try {
-      await this.repository.save(this.repository.create(products));
+      return await this.repository.save(this.repository.create(products));
     } catch (e) {
       this.logger.error(e);
-      return false;
+      return [];
     }
-    return true;
   }
 
   async removeProducts(ids: number[]) {


### PR DESCRIPTION
# 개요
addProducts가 추가된 상품들의 id 배열을 반환하도록 변경하였습니다.

## 작업 내용
- 상품 Service : addProducts에서 추가된 상품의 id 배열을 반환하도록 변경
- 상품 Service : Repository의 addProducts를 호출한 결과인 배열의 길이가 0일 때 에러를 던지도록 수정
- 상품 Resolver : addProducts Mutation의 반환 타입을 정수 배열 타입으로 변경
- 상품 Repository : addProducts에서 상품 객체를 저장하는 데 오류가 발생하면 이를 출력하고, 빈 배열을 반환하도록 수정

## 스크린샷
필요하다면 첨부해주세요.
