### PR TITLE
fix: updateOrderStatus 관련 오류 수정

### DIFF
--- a/src/order/dto/order-status.input.ts
+++ b/src/order/dto/order-status.input.ts
@@ -1,9 +1,11 @@
 import { Field, InputType } from '@nestjs/graphql';
+import { IsEnum } from 'class-validator';
 
 import { OrderStatusType } from '../enum/order-status';
 
 @InputType()
 export class OrderStatusInput {
+  @IsEnum(OrderStatusType)
   @Field(() => OrderStatusType)
   status: OrderStatusType;
 }

--- a/src/order/repository/order.repository.ts
+++ b/src/order/repository/order.repository.ts
@@ -25,6 +25,7 @@ export class OrderRepository {
   }
 
   async updateStatus(id: number, input: IOrderStatus) {
-    return this.repository.update(id, { status: input.status });
+    await this.repository.update(id, { status: input.status });
+    return true;
   }
 }


### PR DESCRIPTION
# 개요
반환 타입이 잘못되어 updateOrderStatus에서 오류가 발생하는 문제를 수정하였습니다.

## 작업 내용
- order Repository의 updateStatus가 boolean을 반환하도록 수정
- OrderStatusInput의 status 프로퍼티에 IsEnum() class-validator Decorator 추가
