### PR TITLE
fix: order-status-default-ready migration 오류 수정

### DIFF
--- a/src/migration/1655730007497-order-status-default-ready.ts
+++ b/src/migration/1655730007497-order-status-default-ready.ts
@@ -5,11 +5,13 @@ export class orderStatusDefaultReady1655730007497 implements MigrationInterface 
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE \`order\` ADD \`status\` enum ('ready', 'done', 'complete', 'canceled') NOT NULL DEFAULT 'ready'`,
+      `ALTER TABLE \`order\` MODIFY \`status\` enum ('ready', 'done', 'complete', 'canceled') NOT NULL DEFAULT 'ready'`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE \`order\` DROP COLUMN \`status\``);
+    await queryRunner.query(
+      `ALTER TABLE \`order\` MODIFY \`status\` enum ('ready', 'done', 'complete', 'canceled') NOT NULL`,
+    );
   }
 }


### PR DESCRIPTION

# 개요
order-status-default-ready 마이그레이션에서 revert할 때 order의 status를 DROP하여 
addOrderStatus에서 revert시 unknown-column 오류가 발생하던 것을 수정하였습니다.

## 작업 내용
- order-status-default-ready의 down 메소드에서 DROP이 아닌 원래 형태로 MODIFY를 하도록 수정
