### PR TITLE
feat: addOrder 관련 기능 추가

### DIFF
--- a/src/order/dto/add-order-product.input.ts
+++ b/src/order/dto/add-order-product.input.ts
@@ -1,0 +1,20 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { ArrayNotEmpty, IsArray, IsInt, IsPositive } from 'class-validator';
+
+@InputType()
+export class OrderProductInput {
+  @IsInt()
+  @Field(() => Int)
+  productId: number;
+
+  @IsInt()
+  @IsPositive()
+  @Field(() => Int)
+  amount: number;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsInt({ each: true })
+  @Field(() => [Int])
+  productOptionIds: number[];
+}

--- a/src/order/dto/add-order.input.ts
+++ b/src/order/dto/add-order.input.ts
@@ -1,0 +1,24 @@
+import { Field, InputType, Int } from '@nestjs/graphql';
+import { Type } from 'class-transformer';
+import { ArrayNotEmpty, IsArray, IsEnum, IsInt, ValidateNested } from 'class-validator';
+
+import { OrderType } from '../enum/order-type';
+import { OrderProductInput } from './add-order-product.input';
+
+@InputType()
+export class AddOrderInput {
+  @IsInt()
+  @Field(() => Int)
+  storeId: number;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @ValidateNested({ each: true })
+  @Field(() => [OrderProductInput])
+  @Type(() => OrderProductInput)
+  products: OrderProductInput[];
+
+  @IsEnum(OrderType)
+  @Field(() => OrderType)
+  type: OrderType;
+}

--- a/src/order/dto/add-order.input.ts
+++ b/src/order/dto/add-order.input.ts
@@ -1,6 +1,6 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { ArrayNotEmpty, IsArray, IsEnum, IsInt, ValidateNested } from 'class-validator';
+import { ArrayNotEmpty, ArrayUnique, IsArray, IsEnum, IsInt, ValidateNested } from 'class-validator';
 
 import { OrderType } from '../enum/order-type';
 import { OrderProductInput } from './add-order-product.input';
@@ -13,6 +13,7 @@ export class AddOrderInput {
 
   @IsArray()
   @ArrayNotEmpty()
+  @ArrayUnique()
   @ValidateNested({ each: true })
   @Field(() => [OrderProductInput])
   @Type(() => OrderProductInput)

--- a/src/order/entity/order.entity.ts
+++ b/src/order/entity/order.entity.ts
@@ -1,6 +1,16 @@
 import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
-import { Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 
+import { Store } from '../../store/entity/store.entity';
 import { OrderStatusType } from '../enum/order-status';
 import { OrderProduct } from './order-product.entity';
 
@@ -33,6 +43,11 @@ export class Order {
   @UpdateDateColumn()
   updatedAt: Date;
 
-  @OneToMany(() => OrderProduct, (item) => item.order)
+  @Field(() => [OrderProduct])
+  @OneToMany(() => OrderProduct, (item) => item.order, { eager: true })
   orderProducts: OrderProduct[];
+
+  @ManyToOne(() => Store, (entity) => entity.orders)
+  @JoinColumn({ name: 'storeId' })
+  store: Store;
 }

--- a/src/order/enum/order-type.ts
+++ b/src/order/enum/order-type.ts
@@ -1,8 +1,8 @@
 import { registerEnumType } from '@nestjs/graphql';
 
 export enum OrderType {
-  HERE = 1,
-  GO = 2,
+  HERE = 'here',
+  GO = 'go',
 }
 
 registerEnumType(OrderType, { name: 'OrderType' });

--- a/src/order/enum/order-type.ts
+++ b/src/order/enum/order-type.ts
@@ -1,0 +1,8 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum OrderType {
+  HERE = 1,
+  GO = 2,
+}
+
+registerEnumType(OrderType, { name: 'OrderType' });

--- a/src/order/interface/add-order-dao.interface.ts
+++ b/src/order/interface/add-order-dao.interface.ts
@@ -1,0 +1,5 @@
+export interface IAddOrderDAO {
+  number: number;
+  price: number;
+  storeId: number;
+}

--- a/src/order/interface/add-order-product-dao.interface.ts
+++ b/src/order/interface/add-order-product-dao.interface.ts
@@ -1,0 +1,6 @@
+export interface IOrderProductDAO {
+  orderId: number;
+  productId: number;
+  productOptionIds: number[];
+  amount: number;
+}

--- a/src/order/interface/add-order-product.interface.ts
+++ b/src/order/interface/add-order-product.interface.ts
@@ -1,0 +1,5 @@
+export interface IOrderProduct {
+  productId: number;
+  amount: number;
+  productOptionIds: number[];
+}

--- a/src/order/interface/add-order.interface.ts
+++ b/src/order/interface/add-order.interface.ts
@@ -1,0 +1,8 @@
+import { OrderType } from '../enum/order-type';
+import { IOrderProduct } from './add-order-product.interface';
+
+export interface IAddOrder {
+  storeId: number;
+  products: IOrderProduct[];
+  type: OrderType;
+}

--- a/src/order/interface/get-amount-of-order.interface.ts
+++ b/src/order/interface/get-amount-of-order.interface.ts
@@ -1,0 +1,7 @@
+export interface IGetAmountOrders {
+  year: number;
+  month: number;
+  day: number;
+  start: number;
+  end: number;
+}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
+import { ProductModule } from '../product/product.module';
 import { OrderProduct } from './entity/order-product.entity';
 import { Order } from './entity/order.entity';
 import { OrderResolver } from './order.resolver';
@@ -9,7 +10,7 @@ import { OrderProductRepository } from './repository/order-product.repository';
 import { OrderRepository } from './repository/order.repository';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order, OrderProduct])],
+  imports: [ProductModule, TypeOrmModule.forFeature([Order, OrderProduct])],
   providers: [OrderResolver, OrderService, OrderRepository, OrderProductRepository],
 })
 export class OrderModule {}

--- a/src/order/order.resolver.ts
+++ b/src/order/order.resolver.ts
@@ -2,6 +2,7 @@ import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nes
 
 import { PaginationArgs } from '../common/dto/pagination.args';
 import { Product } from '../product/entity/product.entity';
+import { AddOrderInput } from './dto/add-order.input';
 import { OrderStatusInput } from './dto/order-status.input';
 import { StoreIdArgs } from './dto/store-id.args';
 import { Order } from './entity/order.entity';
@@ -14,6 +15,11 @@ export class OrderResolver {
   @Query(() => [Order])
   async orders(@Args() args: StoreIdArgs, @Args() paginationArgs: PaginationArgs) {
     return this.orderService.getOrders(args, paginationArgs);
+  }
+
+  @Mutation(() => Int)
+  async addOrder(@Args({ name: 'order', type: () => AddOrderInput }) args: AddOrderInput) {
+    return this.orderService.addOrder(args);
   }
 
   @Mutation(() => Boolean)

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -59,7 +59,8 @@ export class OrderService {
   async getOrderPrice(products: IOrderProduct[]) {
     const productIds = products.map((p) => p.productId);
     const productPrices = await this.getProductPrices(productIds);
-    return products.map((p, idx) => p.amount * productPrices[idx]).reduce((prev, curr) => prev + curr);
+    const totalPriceByProduct = products.map((p, idx) => p.amount * productPrices[idx]);
+    return totalPriceByProduct.reduce((prev, curr) => prev + curr);
   }
 
   async addOrder(args: IAddOrder) {

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -1,6 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 
 import { IPagination } from '../common/interface/pagination';
+import { ProductRepository } from '../product/repository/product.repository';
+import { OrderType } from './enum/order-type';
+import { IOrderProduct } from './interface/add-order-product.interface';
+import { IAddOrder } from './interface/add-order.interface';
 import { IOrderStatus } from './interface/order-status.interface';
 import { IStore } from './interface/store-id.interface';
 import { OrderProductRepository } from './repository/order-product.repository';
@@ -11,6 +15,7 @@ export class OrderService {
   constructor(
     private readonly orderRepository: OrderRepository,
     private readonly orderProductRepository: OrderProductRepository,
+    private readonly productRepository: ProductRepository,
   ) {}
 
   async getOrderProductsByLoader(orderId: number) {
@@ -19,6 +24,54 @@ export class OrderService {
 
   async getOrders(args: IStore, pagination: IPagination) {
     return this.orderRepository.getOrders(args, pagination);
+  }
+
+  async getProductPrices(productIds: number[]) {
+    const products = await this.productRepository.getProductPrices(productIds);
+    return products.map((p) => p.price);
+  }
+
+  async getNumberOfOrders(type: OrderType) {
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth();
+    const day = today.getDate();
+
+    return type == OrderType.HERE
+      ? this.orderRepository.getNumberOfOrders(year, month, day, 1000, 1999)
+      : this.orderRepository.getNumberOfOrders(year, month, day, 2000, 2999);
+  }
+
+  async createOrderNumber(type: OrderType) {
+    const count = await this.getNumberOfOrders(type);
+    if (count >= 999) {
+      throw new InternalServerErrorException('주문 번호가 초과되었습니다.');
+    }
+    return count + 1000 * type + 1;
+  }
+
+  async getOrderPrice(products: IOrderProduct[]) {
+    const productIds = products.map((p) => p.productId);
+    const productPrices = await this.getProductPrices(productIds);
+    return products.map((p, idx) => p.amount * productPrices[idx]).reduce((prev, curr) => prev + curr);
+  }
+
+  async addOrder(args: IAddOrder) {
+    const price = await this.getOrderPrice(args.products);
+    const orderNum = await this.createOrderNumber(args.type);
+    const orderId = await this.orderRepository.addOrder({
+      price: price,
+      storeId: args.storeId,
+      number: orderNum,
+    });
+    const products = args.products.map((product) => {
+      return {
+        orderId: orderId,
+        ...product,
+      };
+    });
+    await this.orderProductRepository.addOrderProducts(products);
+    return orderNum;
   }
 
   async updateOrderStatus(id: number, input: IOrderStatus) {

--- a/src/order/repository/order-product.repository.ts
+++ b/src/order/repository/order-product.repository.ts
@@ -4,6 +4,7 @@ import * as DataLoader from 'dataloader';
 import { In, Repository } from 'typeorm';
 
 import { OrderProduct } from '../entity/order-product.entity';
+import { IOrderProductDAO } from '../interface/add-order-product-dao.interface';
 
 @Injectable()
 export class OrderProductRepository {
@@ -23,5 +24,10 @@ export class OrderProductRepository {
 
   async getOrderProductsByOrderId(orderIds: number[]) {
     return this.repository.findBy({ orderId: In(orderIds) });
+  }
+
+  async addOrderProducts(products: IOrderProductDAO[]) {
+    await this.repository.save(this.repository.create(products));
+    return true;
   }
 }

--- a/src/order/repository/order.repository.ts
+++ b/src/order/repository/order.repository.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Between, Repository } from 'typeorm';
 
 import { IPagination } from '../../common/interface/pagination';
 import { Order } from '../entity/order.entity';
+import { IAddOrderDAO } from '../interface/add-order-dao.interface';
 import { IOrderStatus } from '../interface/order-status.interface';
 import { IStore } from '../interface/store-id.interface';
 
@@ -21,6 +22,20 @@ export class OrderRepository {
       },
       take: pagination.limit,
       skip: pagination.offset,
+    });
+  }
+
+  async addOrder(args: IAddOrderDAO) {
+    const newOrder = await this.repository.save(this.repository.create(args));
+    return newOrder.id;
+  }
+
+  async getNumberOfOrders(year: number, month: number, day: number, start: number, end: number) {
+    return await this.repository.count({
+      where: {
+        createdAt: Between(new Date(year, month, day, 0, 0, 0), new Date(year, month, day, 23, 59, 59)),
+        number: Between(start, end),
+      },
     });
   }
 

--- a/src/order/repository/order.repository.ts
+++ b/src/order/repository/order.repository.ts
@@ -5,6 +5,7 @@ import { Between, Repository } from 'typeorm';
 import { IPagination } from '../../common/interface/pagination';
 import { Order } from '../entity/order.entity';
 import { IAddOrderDAO } from '../interface/add-order-dao.interface';
+import { IGetAmountOrders } from '../interface/get-amount-of-order.interface';
 import { IOrderStatus } from '../interface/order-status.interface';
 import { IStore } from '../interface/store-id.interface';
 
@@ -30,11 +31,14 @@ export class OrderRepository {
     return newOrder.id;
   }
 
-  async getNumberOfOrders(year: number, month: number, day: number, start: number, end: number) {
+  async getAmountOfOrders(args: IGetAmountOrders) {
     return await this.repository.count({
       where: {
-        createdAt: Between(new Date(year, month, day, 0, 0, 0), new Date(year, month, day, 23, 59, 59)),
-        number: Between(start, end),
+        createdAt: Between(
+          new Date(args.year, args.month, args.day, 0, 0, 0),
+          new Date(args.year, args.month, args.day, 23, 59, 59),
+        ),
+        number: Between(args.start, args.end),
       },
     });
   }

--- a/src/product/product.module.ts
+++ b/src/product/product.module.ts
@@ -11,6 +11,6 @@ import { ProductRepository } from './repository/product.repository';
 @Module({
   imports: [TypeOrmModule.forFeature([Product, Option])],
   providers: [ProductResolver, ProductService, ProductRepository, ProductOptionRepository],
-  exports: [ProductService],
+  exports: [ProductService, ProductRepository],
 })
 export class ProductModule {}

--- a/src/product/repository/product.repository.ts
+++ b/src/product/repository/product.repository.ts
@@ -27,6 +27,15 @@ export class ProductRepository {
     return this.repository.findBy({ storeId: In(storeIds) });
   }
 
+  async getProductPrices(productIds: number[]) {
+    return this.repository.find({
+      select: ['price'],
+      where: {
+        id: In(productIds),
+      },
+    });
+  }
+
   async existProductByUniqueIds(ids: number[]) {
     const count = await this.repository.count({ where: { id: In(ids) } });
     return count === ids.length;

--- a/src/store/entity/store.entity.ts
+++ b/src/store/entity/store.entity.ts
@@ -1,6 +1,7 @@
 import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
 import { Column, CreateDateColumn, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
+import { Order } from '../../order/entity/order.entity';
 import { Product } from '../../product/entity/product.entity';
 import { User } from '../../user/entity/user.entity';
 
@@ -43,4 +44,8 @@ export class Store {
 
   @OneToMany(() => Product, (item) => item.store)
   products: Product[];
+
+  @Field(() => [Order])
+  @OneToMany(() => Order, (item) => item.store, { eager: true })
+  orders: Order[];
 }


### PR DESCRIPTION

# 개요
addOrder 관련기능을 추가 했습니다.

## 작업 내용
- order.module.ts : imports에 상품 Module 추가
- order.resolver.ts : addOrder Mutation 추가
- order.service.ts : 상품 Repository 의존성 주입
- order.service.ts : 상품들의 가격을 배열로 반환하는 getProductPrices 메소드 추가
- order.service.ts : Type에 따라 주문의 수를 반환하는 getNumberOfOrder 메소드 추가
- order.service.ts : 주문 번호를 생성하는 createOrderNumber 메소드 추가
- order.service.ts : 주문의 총 가격을 반환하는 getOrderPrice 메소드 추가
- order.service.ts : 주문 및 주문 상품 목록을 추가하는 addOrder 메소드 추가
- add-order-product.input.ts : addOrder Mutation에 사용되는 OrderProductInput dto 추가
- add-order.input.ts : addOrder Mutation에 사용되는 AddOrderInput dto 추가
- order.entity.ts : OrderProduct를 Query에서 받아오기 위한 Field 어노테이션 및 eager 옵션 추가
- order.entity.ts : Store entity와 ManyToOne 관계를 정의 및 Join
- store.entity.ts : Order entity와 oneToMany 관계를 정의
- store.entity.ts : store의 주문을 Query에서 받아오기 위한 Field 어노테이션 및 eager 옵션 추가
- order-type.ts : 주문 유형을 구분하기 위한 OrderType Enum 추가
- add-order.interface.ts : addOrder Service에서 사용되는 IAddOrder interface 추가
- add-order-product.interface.ts : addOrder Service에서 사용되는 IOrderProduct 추가
- add-order-dao.interface.ts : addOrder시 DB 접근을 위한 IAddOrderDAO interface 추가
- add-order-product-dao.interface.ts : addOrder시 DB 접근을 위한 IOrderProductDAO interface 추가
- order-product.repository.ts : OrderProduct 여러 Entity를 추가하는 addOrderProducts 메소드 추가
- order.repository.ts : Order Entity를 추가하는 addOrder 메소드 추가
- order.repository.ts : 시간과 숫자 범위를 받아 범위 내의 Order들을 반환하는 getNumberOfOrders 메소드 추가
- product.module.ts : Order 도메인에서 productRepository를 사용하기 위해 이를 exports에 추가
- product.repository.ts : 상품의 id 배열을 받아 각각의 가격을 받아오는 getProductPrices 메소드 추가



## 스크린샷
![image](https://user-images.githubusercontent.com/56436283/177795431-621d52b0-db52-40e3-83a6-5892d5d889b2.png)

