### PR TITLE
refactor: updateOrderStatus 수정

### DIFF
--- a/src/order/dto/order-status.args.ts
+++ b/src/order/dto/order-status.args.ts
@@ -1,10 +1,10 @@
-import { Field, InputType } from '@nestjs/graphql';
+import { ArgsType, Field } from '@nestjs/graphql';
 import { IsEnum } from 'class-validator';
 
 import { OrderStatusType } from '../enum/order-status';
 
-@InputType()
-export class OrderStatusInput {
+@ArgsType()
+export class OrderStatusArgs {
   @IsEnum(OrderStatusType)
   @Field(() => OrderStatusType)
   status: OrderStatusType;

--- a/src/order/interface/order-status.interface.ts
+++ b/src/order/interface/order-status.interface.ts
@@ -1,5 +1,0 @@
-import { OrderStatusType } from '../enum/order-status';
-
-export interface IOrderStatus {
-  status: OrderStatusType;
-}

--- a/src/order/order.resolver.ts
+++ b/src/order/order.resolver.ts
@@ -3,7 +3,7 @@ import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nes
 import { PaginationArgs } from '../common/dto/pagination.args';
 import { Product } from '../product/entity/product.entity';
 import { AddOrderInput } from './dto/add-order.input';
-import { OrderStatusInput } from './dto/order-status.input';
+import { OrderStatusArgs } from './dto/order-status.args';
 import { StoreIdArgs } from './dto/store-id.args';
 import { Order } from './entity/order.entity';
 import { OrderService } from './order.service';
@@ -23,8 +23,8 @@ export class OrderResolver {
   }
 
   @Mutation(() => Boolean)
-  async updateOrderStatus(@Args('id', { type: () => Int }) id: number, @Args('status') input: OrderStatusInput) {
-    return this.orderService.updateOrderStatus(id, input);
+  async updateOrderStatus(@Args('id', { type: () => Int }) id: number, @Args() args: OrderStatusArgs) {
+    return this.orderService.updateOrderStatus(id, args.status);
   }
 
   @ResolveField(() => [Product])

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -2,10 +2,10 @@ import { BadRequestException, Injectable, InternalServerErrorException } from '@
 
 import { IPagination } from '../common/interface/pagination';
 import { ProductRepository } from '../product/repository/product.repository';
+import { OrderStatusType } from './enum/order-status';
 import { OrderType } from './enum/order-type';
 import { IOrderProduct } from './interface/add-order-product.interface';
 import { IAddOrder } from './interface/add-order.interface';
-import { IOrderStatus } from './interface/order-status.interface';
 import { IStore } from './interface/store-id.interface';
 import { OrderProductRepository } from './repository/order-product.repository';
 import { OrderRepository } from './repository/order.repository';
@@ -81,7 +81,7 @@ export class OrderService {
     return orderNum;
   }
 
-  async updateOrderStatus(id: number, input: IOrderStatus) {
-    return this.orderRepository.updateStatus(id, input);
+  async updateOrderStatus(id: number, status: OrderStatusType) {
+    return this.orderRepository.updateStatus(id, status);
   }
 }

--- a/src/order/repository/order.repository.ts
+++ b/src/order/repository/order.repository.ts
@@ -4,9 +4,9 @@ import { Between, Repository } from 'typeorm';
 
 import { IPagination } from '../../common/interface/pagination';
 import { Order } from '../entity/order.entity';
+import { OrderStatusType } from '../enum/order-status';
 import { IAddOrderDAO } from '../interface/add-order-dao.interface';
 import { IGetAmountOrders } from '../interface/get-amount-of-order.interface';
-import { IOrderStatus } from '../interface/order-status.interface';
 import { IStore } from '../interface/store-id.interface';
 
 @Injectable()
@@ -43,8 +43,8 @@ export class OrderRepository {
     });
   }
 
-  async updateStatus(id: number, input: IOrderStatus) {
-    await this.repository.update(id, { status: input.status });
+  async updateStatus(id: number, status: OrderStatusType) {
+    await this.repository.update(id, { status });
     return true;
   }
 }


### PR DESCRIPTION
# 개요
updateOrderStatus Mutation을 스크린샷과 같이 직관적으로 호출할 수 있도록 변경했습니다.

## 작업 내용
- order.resolver.ts : updateOrderStatus에서 status를 받을 때 inputType이 아닌 ArgsType으로 받도록 수정
- order.service.ts : updateOrderStatus의 두번째 인자의 타입을 OrderStatusType으로 변경
- order-status.args.ts : OrderStatusInput를 OrderStatusArgs로 변경
- order-status.interface.ts(IOrderStatus) 삭제
- order.repository.ts : updateOrderStatus의 두번째 파라미터의 타입을 OrderStatusType으로 변경
## 스크린샷
![image](https://user-images.githubusercontent.com/56436283/177942313-f5d9d611-e5fd-4633-b301-245a0b668ffc.png)
