### PR TITLE
feat: getTodayOrders Query 추가

### DIFF
--- a/src/order/entity/order.entity.ts
+++ b/src/order/entity/order.entity.ts
@@ -47,7 +47,7 @@ export class Order {
   @OneToMany(() => OrderProduct, (item) => item.order, { eager: true })
   orderProducts: OrderProduct[];
 
-  @ManyToOne(() => Store, (entity) => entity.orders)
+  @ManyToOne(() => Store, (entity) => entity.orders, { createForeignKeyConstraints: false })
   @JoinColumn({ name: 'storeId' })
   store: Store;
 }

--- a/src/order/interface/get-today-orders.interface.ts
+++ b/src/order/interface/get-today-orders.interface.ts
@@ -1,0 +1,6 @@
+export interface IGetTodayOrders {
+  year: number;
+  month: number;
+  day: number;
+  storeIds: number[];
+}

--- a/src/order/order.module.ts
+++ b/src/order/order.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { ProductModule } from '../product/product.module';
+import { StoreModule } from '../store/store.module';
 import { OrderProduct } from './entity/order-product.entity';
 import { Order } from './entity/order.entity';
 import { OrderResolver } from './order.resolver';
@@ -10,7 +11,7 @@ import { OrderProductRepository } from './repository/order-product.repository';
 import { OrderRepository } from './repository/order.repository';
 
 @Module({
-  imports: [ProductModule, TypeOrmModule.forFeature([Order, OrderProduct])],
+  imports: [StoreModule, ProductModule, TypeOrmModule.forFeature([Order, OrderProduct])],
   providers: [OrderResolver, OrderService, OrderRepository, OrderProductRepository],
 })
 export class OrderModule {}

--- a/src/order/order.resolver.ts
+++ b/src/order/order.resolver.ts
@@ -1,6 +1,8 @@
 import { Args, Int, Mutation, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 
+import { RequestInfo } from '../common/decorator';
 import { PaginationArgs } from '../common/dto/pagination.args';
+import { IRequest } from '../common/interface/request';
 import { Product } from '../product/entity/product.entity';
 import { AddOrderInput } from './dto/add-order.input';
 import { RemoveOrderProductInput } from './dto/delete-order-product.input';
@@ -22,6 +24,11 @@ export class OrderResolver {
   @Query(() => [Order])
   async orders(@Args() args: StoreIdArgs, @Args() paginationArgs: PaginationArgs) {
     return this.orderService.getOrders(args, paginationArgs);
+  }
+
+  @Query(() => [Order])
+  async todayOrders(@RequestInfo() req: Required<IRequest>, @Args() paginationArgs: PaginationArgs) {
+    return this.orderService.getTodayOrders(req.user.id, paginationArgs);
   }
 
   @Mutation(() => Int)

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, InternalServerErrorException } from '@
 
 import { IPagination } from '../common/interface/pagination';
 import { ProductRepository } from '../product/repository/product.repository';
+import { StoreRepository } from '../store/repository/store.repository';
 import { OrderStatusType } from './enum/order-status';
 import { OrderType } from './enum/order-type';
 import { IAddOrderProduct } from './interface/add-order-product.interface';
@@ -16,6 +17,7 @@ export class OrderService {
   constructor(
     private readonly orderRepository: OrderRepository,
     private readonly orderProductRepository: OrderProductRepository,
+    private readonly storeRepository: StoreRepository,
     private readonly productRepository: ProductRepository,
   ) {}
 
@@ -25,6 +27,18 @@ export class OrderService {
 
   async getOrders(args: IStore, pagination: IPagination) {
     return this.orderRepository.getOrders(args, pagination);
+  }
+
+  async getTodayOrders(ownerId: number, pagination: IPagination) {
+    const stores = await this.storeRepository.getStoreIdsByUserId(ownerId);
+    const storeIds = stores.map((store) => store.id);
+
+    const today = new Date();
+    const year = today.getFullYear();
+    const month = today.getMonth();
+    const day = today.getDate();
+
+    return this.orderRepository.getTodayOrders({ year, month, day, storeIds }, pagination);
   }
 
   async getProductPrices(productIds: number[]) {

--- a/src/order/repository/order.repository.ts
+++ b/src/order/repository/order.repository.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { Between, In, Repository } from 'typeorm';
 
 import { IPagination } from '../../common/interface/pagination';
 import { Order } from '../entity/order.entity';
 import { OrderStatusType } from '../enum/order-status';
 import { IAddOrderDAO } from '../interface/add-order-dao.interface';
 import { IGetAmountOrders } from '../interface/get-amount-of-order.interface';
+import { IGetTodayOrders } from '../interface/get-today-orders.interface';
 import { IStore } from '../interface/store-id.interface';
 
 @Injectable()
@@ -28,6 +29,23 @@ export class OrderRepository {
 
   async getOrderProducts(id: number) {
     return this.repository.findOne({ select: ['orderProducts'], where: { id: id } });
+  }
+
+  async getTodayOrders(args: IGetTodayOrders, pagination: IPagination) {
+    return this.repository.find({
+      where: {
+        storeId: In(args.storeIds),
+        createdAt: Between(
+          new Date(args.year, args.month, args.day, 0, 0, 0),
+          new Date(args.year, args.month, args.day, 23, 59, 59),
+        ),
+      },
+      order: {
+        id: 'DESC',
+      },
+      take: pagination.limit,
+      skip: pagination.offset,
+    });
   }
 
   async addOrder(args: IAddOrderDAO) {

--- a/src/store/repository/store.repository.ts
+++ b/src/store/repository/store.repository.ts
@@ -18,6 +18,10 @@ export class StoreRepository {
     return this.repository.findBy({ ownerId });
   }
 
+  async getStoreIdsByUserId(ownerId: number) {
+    return this.repository.find({ where: { ownerId }, select: ['id'] });
+  }
+
   async getStoreById(id: number) {
     return this.repository.findOneBy({ id });
   }

--- a/src/store/store.module.ts
+++ b/src/store/store.module.ts
@@ -11,5 +11,6 @@ import { StoreService } from './store.service';
 @Module({
   imports: [ProductModule, TypeOrmModule.forFeature([Store, Option])],
   providers: [StoreResolver, StoreService, StoreRepository],
+  exports: [StoreRepository],
 })
 export class StoreModule {}


### PR DESCRIPTION
# 개요
오늘의 주문만을 불러오는 todayOrders Query를 추가하였습니다.

## 작업 내용
- order.resolver.ts : 오늘의 주문만을 불러오는 todayOrders Resolver 추가
- order.module.ts : StoreModule 사용을 위해 imports에 추가
- order.service.ts : 오늘의 주문만을 불러오는 getTodayOrders 메소드 추가
- order.service.ts : 시간 정보를 repository단으로 넘기도록 함.
- get-today-orders.interface.ts : getTodayOrders에서 사용되는 IGetTodayOrders 인터페이스 추가
- order.repository.ts : createdAt 컬럼을 통해 오늘만의 주문을 불러오는 getTodayOrders 메소드 추가
- store.module.ts : Store Repository를 exports에 추가
- store.repository.ts : 소유자id를 통해 storeId들만을 불러오는 getStoreIdsByUserId 메소드 추가
- order.entity.ts : store에 대해 createForeignkeyConstraints를 false로 설정

## 스크린샷
MyStores 호출방식과 동일하게 token을 header에 담아서 다음과 같이 요청하시면 됩니다.
![image](https://user-images.githubusercontent.com/56436283/178778028-93045272-a749-4e70-82c7-31825ac1277f.png)


전체 주문 정보는 기존 MyStores에서 order를 불러오는 방식을 사용하시면 됩니다.
pull requests 내용을 작성하실때 'resolve: #[이슈넘버]'를 넣어주시면 merge될 때, 깃허브에서 자동으로 이슈를 close해줍니다.
