### PR TITLE
feat: addOrder할 때, 아임포트 결제 정보 등록 시키도록 변경

### DIFF
--- a/src/migration/1657703810764-addImpUidAndMerchantUid.ts
+++ b/src/migration/1657703810764-addImpUidAndMerchantUid.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class addImpUidAndMerchantUid1657703810764 implements MigrationInterface {
+  name = 'addImpUidAndMerchantUid1657703810764';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`order\` ADD \`imp_uid\` varchar(16) NOT NULL`);
+    await queryRunner.query(`ALTER TABLE \`order\` ADD \`merchant_uid\` varchar(40) NOT NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`order\` DROP COLUMN \`merchant_uid\``);
+    await queryRunner.query(`ALTER TABLE \`order\` DROP COLUMN \`imp_uid\``);
+  }
+}

--- a/src/migration/1657703810764-addImpUidAndMerchantUid.ts
+++ b/src/migration/1657703810764-addImpUidAndMerchantUid.ts
@@ -4,8 +4,8 @@ export class addImpUidAndMerchantUid1657703810764 implements MigrationInterface 
   name = 'addImpUidAndMerchantUid1657703810764';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE \`order\` ADD \`imp_uid\` varchar(16) NOT NULL`);
-    await queryRunner.query(`ALTER TABLE \`order\` ADD \`merchant_uid\` varchar(40) NOT NULL`);
+    await queryRunner.query(`ALTER TABLE \`order\` ADD \`imp_uid\` varchar(16) NOT NULL DEFAULT 'null'`);
+    await queryRunner.query(`ALTER TABLE \`order\` ADD \`merchant_uid\` varchar(40) NOT NULL DEFAULT 'null'`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/src/order/dto/add-order.input.ts
+++ b/src/order/dto/add-order.input.ts
@@ -1,6 +1,15 @@
 import { Field, InputType, Int } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { ArrayNotEmpty, ArrayUnique, IsArray, IsEnum, IsInt, ValidateNested } from 'class-validator';
+import {
+  ArrayNotEmpty,
+  ArrayUnique,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsString,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
 
 import { OrderType } from '../enum/order-type';
 import { OrderProductInput } from './add-order-product.input';
@@ -10,6 +19,16 @@ export class AddOrderInput {
   @IsInt()
   @Field(() => Int)
   storeId: number;
+
+  @IsString()
+  @MaxLength(16)
+  @Field()
+  imp_uid: string;
+
+  @IsString()
+  @MaxLength(40)
+  @Field()
+  merchant_uid: string;
 
   @IsArray()
   @ArrayNotEmpty()

--- a/src/order/entity/order.entity.ts
+++ b/src/order/entity/order.entity.ts
@@ -33,6 +33,14 @@ export class Order {
   @Column({ type: 'int' })
   storeId: number;
 
+  @Field()
+  @Column({ type: 'varchar', length: 16 })
+  imp_uid: string;
+
+  @Field()
+  @Column({ type: 'varchar', length: 40 })
+  merchant_uid: string;
+
   @Field(() => OrderStatusType)
   @Column({ type: 'enum', enum: OrderStatusType, default: OrderStatusType.READY })
   status: OrderStatusType;

--- a/src/order/interface/add-order-dao.interface.ts
+++ b/src/order/interface/add-order-dao.interface.ts
@@ -2,4 +2,6 @@ export interface IAddOrderDAO {
   number: number;
   price: number;
   storeId: number;
+  imp_uid: string;
+  merchant_uid: string;
 }

--- a/src/order/interface/add-order.interface.ts
+++ b/src/order/interface/add-order.interface.ts
@@ -3,6 +3,8 @@ import { IOrderProduct } from './add-order-product.interface';
 
 export interface IAddOrder {
   storeId: number;
+  imp_uid: string;
+  merchant_uid: string;
   products: IOrderProduct[];
   type: OrderType;
 }

--- a/src/order/order.service.ts
+++ b/src/order/order.service.ts
@@ -69,6 +69,8 @@ export class OrderService {
     const orderId = await this.orderRepository.addOrder({
       price: price,
       storeId: args.storeId,
+      imp_uid: args.imp_uid,
+      merchant_uid: args.merchant_uid,
       number: orderNum,
     });
     const products = args.products.map((product) => {


### PR DESCRIPTION
# 개요
merchant_uid, imp_uid 컬럼을 추가하였으며 이를 주문 추가할 때 db에 저장하도록 하였습니다.

## 작업 내용
- order.entity.ts : merchant_uid, imp_uid 컬럼 추가
- order entity 수정사항에 따른 addImpUidAndMerchantUid1657703810764 마이그레이션 추가
- add-order, add-order-dao 인터페이스에 merchant_uid, imp_uid 추가
- order.service.ts: imp_uid, merchant_uid 포함시켜 Repository의 addOrder 호출
- add-order.input.ts: imp_uid, merchant_uid 필드 추가 및 길이 제한 validator 추가
