### PR TITLE
fix: updateOrderStatus return 타입 불일치 수정

### DIFF
--- a/src/order/repository/order.repository.ts
+++ b/src/order/repository/order.repository.ts
@@ -67,6 +67,7 @@ export class OrderRepository {
 
   async updateStatus(id: number, status: OrderStatusType) {
     await this.repository.update(id, { status });
+    return true;
   }
 
   async updateOrderPrice(id: number, price: number) {


### PR DESCRIPTION

# 개요
updateOrderStatus return 타입 불일치 수정

## 작업 내용
- order.repository.ts : updateStatus 메소드가 true를 반환하도록 수정
