### PR TITLE
feat: 여러개의 option을 업데이트할 수 있도록 수정

### DIFF
--- a/src/product/interface/edit-option.interface.ts
+++ b/src/product/interface/edit-option.interface.ts
@@ -1,3 +1,4 @@
 export interface IEditOption {
+  optionId: number;
   name: string;
 }

--- a/src/product/product.resolver.ts
+++ b/src/product/product.resolver.ts
@@ -42,8 +42,10 @@ export class ProductResolver {
   }
 
   @Mutation(() => Boolean)
-  async updateProductOption(@Args({ name: 'option', type: () => EditProductOptionInput }) arg: EditProductOptionInput) {
-    return this.productService.updateOption(arg.optionId, arg);
+  async updateProductOptions(
+    @Args({ name: 'option', type: () => [EditProductOptionInput] }) args: EditProductOptionInput[],
+  ) {
+    return this.productService.updateOptions(args);
   }
 
   @Mutation(() => Boolean)

--- a/src/product/product.service.ts
+++ b/src/product/product.service.ts
@@ -58,8 +58,11 @@ export class ProductService {
     return this.productOptionRepository.addOptions(options);
   }
 
-  async updateOption(optionId: number, option: IEditOption) {
-    return this.productOptionRepository.updateOption(optionId, option);
+  async updateOptions(options: IEditOption[]) {
+    for (const option of options) {
+      await this.productOptionRepository.updateOption(option);
+    }
+    return true;
   }
 
   async removeOptions(optionIds: number[]) {

--- a/src/product/repository/product-option.repository.ts
+++ b/src/product/repository/product-option.repository.ts
@@ -37,8 +37,9 @@ export class ProductOptionRepository {
     return true;
   }
 
-  async updateOption(optionId: number, option: IEditOption) {
-    await this.repository.update(optionId, this.repository.create(option));
+  async updateOption(option: IEditOption) {
+    const updatedOptions = this.repository.create(option);
+    await this.repository.update(option.optionId, updatedOptions);
     return true;
   }
 }


### PR DESCRIPTION


# 개요
여러개의 option을 업데이트할 수 있도록 수정

## 작업 내용
- product.resolver.ts : 여러개의 옵션을 받도록 updateProductOption을 updateProductOptions로 수정
- product.service.ts : updateOption -> updateOptions로 메소드명 변경 및 로직 변경
- edit-option.interface.ts : optionId 필드 추가
- product-option.repository.ts : updateOption의 optionId 파라미터 제거

## 스크린샷
![image](https://user-images.githubusercontent.com/56436283/179206947-4d2c5b74-7156-411f-a929-39fadb102f36.png)
